### PR TITLE
Fix `python.number` pattern

### DIFF
--- a/lark/grammars/python.lark
+++ b/lark/grammars/python.lark
@@ -228,7 +228,7 @@ COMMENT: /#[^\n]*/
 STRING : /[ubf]?r?("(?!"").*?(?<!\\)(\\\\)*?"|'(?!'').*?(?<!\\)(\\\\)*?')/i
 LONG_STRING: /[ubf]?r?(""".*?(?<!\\)(\\\\)*?"""|'''.*?(?<!\\)(\\\\)*?''')/is
 
-DEC_NUMBER: /0|[1-9][\d_]*/i
+DEC_NUMBER: /0|\d(?:_?\d)*/i
 HEX_NUMBER.2: /0x[\da-f]*/i
 OCT_NUMBER.2: /0o[0-7]*/i
 BIN_NUMBER.2 : /0b[0-1]*/i

--- a/lark/grammars/python.lark
+++ b/lark/grammars/python.lark
@@ -207,7 +207,7 @@ encoding_decl: NAME
 yield_expr: "yield" [testlist]
           | "yield" "from" test -> yield_from
 
-number: DEC_NUMBER | HEX_NUMBER | BIN_NUMBER | OCT_NUMBER | FLOAT_NUMBER | IMAG_NUMBER
+number: DEC_NUMBER | HEX_NUMBER | BIN_NUMBER | OCT_NUMBER | FLOAT_NUMBER | COMPLEX_NUMBER
 string: STRING | LONG_STRING
 
 // Other terminals
@@ -231,9 +231,10 @@ LONG_STRING: /[ubf]?r?(""".*?(?<!\\)(\\\\)*?"""|'''.*?(?<!\\)(\\\\)*?''')/is
 DEC_NUMBER: /0|\d(?:_?\d)*/i
 HEX_NUMBER.2: /0x[\da-f]*/i
 OCT_NUMBER.2: /0o[0-7]*/i
-BIN_NUMBER.2 : /0b[0-1]*/i
-FLOAT_NUMBER.2: /((\d+\.[\d_]*|\.[\d_]+)([Ee][-+]?\d+)?|\d+([Ee][-+]?\d+))/
-IMAG_NUMBER.2: /\d+[Jj]/ | FLOAT_NUMBER /[Jj]/
+BIN_NUMBER.2: /0b[0-1]*/i
+FLOAT_NUMBER.2: (DEC_NUMBER "." DEC_NUMBER? | "." DEC_NUMBER) (("E" | "e") ["+" | "-"] DEC_NUMBER)?
+              | DEC_NUMBER (("E" | "e") ["+" | "-"] DEC_NUMBER)?
+COMPLEX_NUMBER.2: (DEC_NUMBER | FLOAT_NUMBER) ("+" | "-") (DEC_NUMBER | FLOAT_NUMBER) ("J" | "j")
 
 
 // Comma-separated list (with an optional trailing comma)


### PR DESCRIPTION
Python doesn't accept numbers with the `_` in the beginning / end:
```python
>>> 69420
69420
>>> 69_420
69420
>>> 69_420_
  File "<stdin>", line 1
    69_420_
          ^
SyntaxError: invalid decimal literal
>>> _69_420
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name '_69_420' is not defined
```

```python
>>> 03.1415
3.1415
>>> 0_3.14_15
3.1415
>>> 0_3.14_15_
  File "<stdin>", line 1
    0_3.14_15_
             ^
SyntaxError: invalid decimal literal
>>> 0_3._14_15
  File "<stdin>", line 1
    0_3._14_15
       ^
SyntaxError: invalid decimal literal
>>> 0_3_.14_15
  File "<stdin>", line 1
    0_3_.14_15
       ^
SyntaxError: invalid decimal literal
>>> _0_3.14_15
  File "<stdin>", line 1
    _0_3.14_15
    ^^^^^^^^^^
SyntaxError: invalid syntax. Perhaps you forgot a comma?
```

the same goes with complex numbers. And yes, python recognizes `_xxx` as a name, regardless of the fact that x is a digit, but it's still not a number, so this doesn't affect us.

The current implementation only filters numbers with `_` in the begging, so I wanna fix other cases.

---

I also tested `\d(?:_?\d+)*` but haven't seen any significant performance changes.

todo:
- [x] int
- [x] float
- [x] complex